### PR TITLE
SP-63 changed xdebug default status to disabled

### DIFF
--- a/dev/app/init.sls
+++ b/dev/app/init.sls
@@ -50,8 +50,8 @@ php:
   # Default: xdebug is enabled only if role 'dev' is included
   # xhprof is disabled
   # Optional
-  #enable_xdebug: true
   #enable_xhprof: true
+  enable_xdebug: false
 
   # PHP OpCache.
   # Optional, default: enabled


### PR DESCRIPTION
Disabled the xdebug for default enviroment. 

Ticket Numbers: https://spryker.atlassian.net/browse/SP-63
Sub PR's: 
Reviewed by:
Develop ready approved by:
